### PR TITLE
fix for scope matching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Configuration
 
 ``current_app.config`` should contain the following configuration details:
 
-:``TOKEN_ENDPONT``: (e.g. "https://tokens.indieauth.org/token")
+:``TOKEN_ENDPOINT``: (e.g. "https://tokens.indieauth.com/token")
 :``ME``: (e.g. "http://example.com")
 
 **Example Usage**::

--- a/flask_indieauth.py
+++ b/flask_indieauth.py
@@ -95,9 +95,10 @@ def check_auth(access_token):
     if not isinstance(scope, str):
         scope = scope[0]
     valid_scopes = ('post','create', )
-    valid_scope = (len([val for val in valid_scopes if val in scope]) > 0)
+    scope_ = scope.split()
+    scope_valid = any((val in scope_) for val in valid_scopes)
 
-    if not valid_scope:
+    if not scope_valid:
         current_app.logger.error("Scope '%s' does not contain 'post' or 'create'." % scope)
         return deny("Scope '%s' does not contain 'post' or 'create'." % scope)
 


### PR DESCRIPTION
the existing code matched as long as any substring in the scope parameter was a valid scope (so e.g. a scope of `posts` would match since it contains `post`). This PR now splits the scopes (which per OAuth specification have to be space delimited) and then compares them individually.

(Also small spellfixes not worthy an extra PR in an extra commit)